### PR TITLE
Support retry with 404 status in classic api again

### DIFF
--- a/classic/computer_extension_attributes.go
+++ b/classic/computer_extension_attributes.go
@@ -140,6 +140,8 @@ func (s *ComputerExtensionAttributesService) Create(ctx context.Context, compute
 func (s *ComputerExtensionAttributesService) Delete(ctx context.Context, computerExtensionAttributeID int) (*jamf.Response, error) {
 	resp, _, err := s.client.Delete(ctx, jamf.DeleteHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(computerExtensionAttributesPath, "id", fmt.Sprint(computerExtensionAttributeID)),
 		},
@@ -235,6 +237,8 @@ func (s *ComputerExtensionAttributesService) Update(ctx context.Context, compute
 
 	resp, _, err := s.client.Put(ctx, jamf.PutHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusCreated},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(computerExtensionAttributesPath, "id", fmt.Sprint(*computerExtensionAttribute.ID)),
 		},

--- a/classic/computer_groups.go
+++ b/classic/computer_groups.go
@@ -153,6 +153,8 @@ func (s *ComputerGroupsService) Create(ctx context.Context, computerGroup *Compu
 func (s *ComputerGroupsService) Delete(ctx context.Context, computerGroupID int) (*jamf.Response, error) {
 	resp, _, err := s.client.Delete(ctx, jamf.DeleteHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(computerGroupsPath, "id", fmt.Sprint(computerGroupID)),
 		},
@@ -251,6 +253,8 @@ func (s *ComputerGroupsService) Update(ctx context.Context, computerGroup *Compu
 
 	resp, _, err := s.client.Put(ctx, jamf.PutHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusCreated},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(computerGroupsPath, "id", fmt.Sprint(*computerGroup.ID)),
 		},

--- a/classic/osx_configuration_profiles.go
+++ b/classic/osx_configuration_profiles.go
@@ -236,6 +236,8 @@ func (s *OSXConfigurationProfilesService) Create(ctx context.Context, osxConfigu
 func (s *OSXConfigurationProfilesService) Delete(ctx context.Context, osxConfigurationProfileID int) (*jamf.Response, error) {
 	resp, _, err := s.client.Delete(ctx, jamf.DeleteHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(osxConfigurationProfilesPath, "id", fmt.Sprint(osxConfigurationProfileID)),
 		},
@@ -334,6 +336,8 @@ func (s *OSXConfigurationProfilesService) Update(ctx context.Context, osxConfigu
 
 	resp, _, err := s.client.Put(ctx, jamf.PutHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusCreated},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(osxConfigurationProfilesPath, "id", fmt.Sprint(*osxConfigurationProfile.General.ID)),
 		},

--- a/classic/packages.go
+++ b/classic/packages.go
@@ -118,6 +118,8 @@ func (s *PackagesService) Create(ctx context.Context, pkg *Package) (*int, *jamf
 func (s *PackagesService) Delete(ctx context.Context, packageID int) (*jamf.Response, error) {
 	resp, _, err := s.client.Delete(ctx, jamf.DeleteHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(packagesPath, "id", fmt.Sprint(packageID)),
 		},
@@ -210,6 +212,8 @@ func (s *PackagesService) Update(ctx context.Context, pkg *Package) (*jamf.Respo
 
 	resp, _, err := s.client.Put(ctx, jamf.PutHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusCreated},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(packagesPath, "id", fmt.Sprint(*pkg.ID)),
 		},

--- a/classic/policies.go
+++ b/classic/policies.go
@@ -732,6 +732,8 @@ func (s *PoliciesService) Create(ctx context.Context, policy *Policy) (*int, *ja
 func (s *PoliciesService) Delete(ctx context.Context, policyID int) (*jamf.Response, error) {
 	resp, _, err := s.client.Delete(ctx, jamf.DeleteHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(policiesPath, "id", fmt.Sprint(policyID)),
 		},
@@ -747,6 +749,8 @@ func (s *PoliciesService) Delete(ctx context.Context, policyID int) (*jamf.Respo
 func (s *PoliciesService) Get(ctx context.Context, policyID int) (*Policy, *jamf.Response, error) {
 	resp, _, err := s.client.Get(ctx, jamf.GetHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusOK},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(policiesPath, "id", fmt.Sprint(policyID)),
 		},
@@ -828,6 +832,8 @@ func (s *PoliciesService) Update(ctx context.Context, policy *Policy) (*jamf.Res
 
 	resp, _, err := s.client.Put(ctx, jamf.PutHttpRequestInput{
 		ValidStatusCodes: []int{http.StatusCreated},
+		// The API may return a 404, e.g., when a resource is just created.
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
 		Uri: jamf.Uri{
 			Entity: path.Join(policiesPath, "id", fmt.Sprint(*policy.General.ID)),
 		},


### PR DESCRIPTION
The response was incomplete, although the modifications were made at https://github.com/kenchan0130/go-jamf-pro/pull/3. 
Therefore, I have addressed it again in this PR.